### PR TITLE
fix compilation error when using language verion 14

### DIFF
--- a/async.cs
+++ b/async.cs
@@ -1054,12 +1054,12 @@ namespace Mono.CSharp
 
 		public bool IsAvailableForReuse {
 			get {
-				var field = (Field) spec.MemberDefinition;
-				return field.IsAvailableForReuse;
+				var @field = (Field) spec.MemberDefinition;
+				return @field.IsAvailableForReuse;
 			}
 			private set {
-				var field = (Field) spec.MemberDefinition;
-				field.IsAvailableForReuse = value;
+				var @field = (Field) spec.MemberDefinition;
+				@field.IsAvailableForReuse = value;
 			}
 		}
 


### PR DESCRIPTION
I was trying to compile the project then ran into this, because it's using "latest" langversion.

error CS9273: In language version 14.0, 'field' is a keyword within a property accessor. Rename the variable or use the identifier '@field' instead.